### PR TITLE
Fix Linux/Mac OS installation in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Installation
 
 .. code:: sh
 
-    sudo apt pip3 install pyspapi
+    pip3 install pyspapi
 
 Quick example
 --------------


### PR DESCRIPTION
In Linux and OS X you **don't need** run `pip3 install` with `sudo apt`. Apt is the package manager in Debian-like systems, Sudo is utility for substituting user by other user. Both of them aren't needed and also this command **causes error**. Example:

![Screenshot_20230109_105502](https://user-images.githubusercontent.com/83695097/211262097-e244c48a-68a6-4dac-ac83-bd581d326a09.png)

(Pacman instead of apt, because I use Arch. But it doesn't matter)

![Screenshot_20230109_105653](https://user-images.githubusercontent.com/83695097/211262349-f83060d3-cd83-44d2-8047-6afb27fc28be.png)

